### PR TITLE
Auto pickup and block break changes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ yarn_mappings=1.16.4+build.7
 loader_version=0.10.8
 
 # Mod Properties
-mod_version=1.4.3
+mod_version=1.4.4
 maven_group=draylar
 archives_base_name=magna
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,9 +3,9 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 # check these on https://fabricmc.net/use
-minecraft_version=1.16.2
-yarn_mappings=1.16.2+build.1
-loader_version=0.9.1+build.205
+minecraft_version=1.16.4
+yarn_mappings=1.16.4+build.7
+loader_version=0.10.8
 
 # Mod Properties
 mod_version=1.4.3
@@ -14,7 +14,7 @@ archives_base_name=magna
 
 # Dependencies
 # currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
-fabric_version=0.17.2+build.396-1.16
+fabric_version=0.26.3+1.16
 cloth_config_version=4.7.0-unstable
 auto_config_version=3.2.0-unstable
 mod_menu_version=1.14.6+build.31

--- a/src/main/java/draylar/magna/api/MagnaPlayerInteractionManagerExtension.java
+++ b/src/main/java/draylar/magna/api/MagnaPlayerInteractionManagerExtension.java
@@ -1,0 +1,6 @@
+package draylar.magna.api;
+
+public interface MagnaPlayerInteractionManagerExtension {
+    boolean isMining();
+    void setMining(boolean mining);
+}

--- a/src/main/java/draylar/magna/config/MagnaConfig.java
+++ b/src/main/java/draylar/magna/config/MagnaConfig.java
@@ -26,4 +26,7 @@ public class MagnaConfig implements ConfigData {
 
     @Comment(value = "Whether each block in an extended hitbox should show its outline separately.")
     public boolean individualBlockOutlines = false;
+
+    @Comment(value = "Auto picks up items instead of dropping on the ground.")
+    public boolean autoPickup = false;
 }


### PR DESCRIPTION
- Auto pickup
Tries to insert item directly into the inventory and drop any remainders to avoid spamming item entities with hammers or larger radius tools.
- Block break changes
1. Changed the priority of the mixin to make it go after Fabric's callback so any other checks (mainly protection mods) run first.
2. Run "tryBreakBlock" for every block to and ignore if it's cancelled. The `MagnaPlayerInteractionManagerExtension` interface was made to avoid recursively calling the `breakInRadius` logic. It cancels the callback because all the block break handling is done by that method.

Note that even with those changes it still only works with Flan because GOML doesn't register a BlockBreak callback so you can still bypass GOML claims using Magna.