### PR TITLE
Extract position finding to interface

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     modImplementation "com.terraformersmc:modmenu:${project.mod_menu_version}"
 
     // dev Reach Entity Attributes for testing tools with extended reach (or players)
-    modImplementation "com.jamieswhiteshirt:reach-entity-attributes:1.0.1"
+    modImplementation "com.jamieswhiteshirt:reach-entity-attributes:${project.rea_version}"
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,9 +3,10 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 # check these on https://fabricmc.net/use
-minecraft_version=1.17-pre4
-yarn_mappings=1.17-pre4+build.1
-loader_version=0.11.3
+minecraft_version=1.17.1
+yarn_mappings=1.17.1+build.37
+loader_version=0.11.6
+
 # Mod Properties
 mod_version=1.5.5
 maven_group=draylar
@@ -13,6 +14,7 @@ archives_base_name=magna
 
 # Dependencies
 # currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
-fabric_version=0.34.8+1.17
-cloth_config_version=5.0.33
-mod_menu_version=2.0.0-beta.7
+fabric_version=0.37.2+1.17
+cloth_config_version=5.0.38
+mod_menu_version=2.0.4
+rea_version=2.1.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ yarn_mappings=1.17.1+build.37
 loader_version=0.11.6
 
 # Mod Properties
-mod_version=1.5.5
+mod_version=1.6.0
 maven_group=draylar
 archives_base_name=magna
 

--- a/src/main/java/draylar/magna/MagnaTest.java
+++ b/src/main/java/draylar/magna/MagnaTest.java
@@ -3,7 +3,7 @@ package draylar.magna;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
 import com.jamieswhiteshirt.reachentityattributes.ReachEntityAttributes;
-import draylar.magna.api.MagnaTool;
+import draylar.magna.api.BlockFinder;
 import draylar.magna.item.ExcavatorItem;
 import draylar.magna.item.HammerItem;
 import net.minecraft.entity.EquipmentSlot;
@@ -15,8 +15,11 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.ToolMaterials;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.registry.Registry;
 import net.minecraft.world.World;
+
+import java.util.List;
 
 /**
  * This class is responsible for registering development-environment test items.
@@ -84,6 +87,28 @@ public class MagnaTest {
                     @Override
                     public int getDepth(ItemStack stack) {
                         return 15;
+                    }
+                }
+        );
+
+        // Hammer that only breaks blocks inside its radius with an odd x or (exclusive) z position.
+        Registry.register(
+                Registry.ITEM,
+                new Identifier("magna", "custom_breaker_test"),
+                new HammerItem(ToolMaterials.DIAMOND, 0, 0, new Item.Settings()) {
+                    private final BlockFinder TEST_FINDER = new BlockFinder() {
+                        @Override
+                        public List<BlockPos> findPositions(World world, PlayerEntity playerEntity, int radius, int depth) {
+                            return BlockFinder.super.findPositions(world, playerEntity, radius, depth)
+                                    .stream()
+                                    .filter((pos) -> pos.getX() % 2 == 0 ^ pos.getZ() % 2 == 0)
+                                    .toList();
+                        }
+                    };
+
+                    @Override
+                    public BlockFinder getBlockFinder() {
+                        return TEST_FINDER;
                     }
                 }
         );

--- a/src/main/java/draylar/magna/api/BlockFinder.java
+++ b/src/main/java/draylar/magna/api/BlockFinder.java
@@ -1,0 +1,111 @@
+package draylar.magna.api;
+
+import draylar.magna.api.reach.ReachDistanceHelper;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Hand;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.util.hit.HitResult;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.util.math.Vec3i;
+import net.minecraft.world.RaycastContext;
+import net.minecraft.world.World;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public interface BlockFinder {
+    BlockFinder DEFAULT = new BlockFinder() {};
+
+    /**
+     * Returns positions with a depth of 0.
+     * @see BlockFinder#findPositions(World, PlayerEntity, int, int)
+     */
+    default List<BlockPos> findPositions(World world, PlayerEntity playerEntity, int radius) {
+        return findPositions(world, playerEntity, radius, 0);
+    }
+
+    /**
+     * Returns a list of {@link BlockPos} in the given radius considering the {@link PlayerEntity}'s facing direction.
+     *
+     * @param world         world to check in
+     * @param playerEntity  player that is collecting blocks
+     * @param radius        radius to collect blocks in
+     * @param depth         the depth away from the player to break
+     * @return              a list of blocks that would be broken with the given radius and tool
+     */
+    default List<BlockPos> findPositions(World world, PlayerEntity playerEntity, int radius, int depth) {
+        ArrayList<BlockPos> potentialBrokenBlocks = new ArrayList<>();
+
+        // collect information on camera
+        Vec3d cameraPos = playerEntity.getCameraPosVec(1);
+        Vec3d rotation = playerEntity.getRotationVec(1);
+        double reachDistance = ReachDistanceHelper.getReachDistance(playerEntity);
+        Vec3d combined = cameraPos.add(rotation.x * reachDistance, rotation.y * reachDistance, rotation.z * reachDistance);
+
+        // find block the player is currently looking at
+        BlockHitResult blockHitResult = world.raycast(new RaycastContext(cameraPos, combined, RaycastContext.ShapeType.OUTLINE, RaycastContext.FluidHandling.NONE, playerEntity));
+
+        // only show an extended hitbox if the player is looking at a block
+        if (blockHitResult.getType() == HitResult.Type.BLOCK) {
+            Direction.Axis axis = blockHitResult.getSide().getAxis();
+            ArrayList<Vec3i> positions = new ArrayList<>();
+
+            // create a box using the given radius
+            for(int x = -radius; x <= radius; x++) {
+                for(int y = -radius; y <= radius; y++) {
+                    for(int z = -radius; z <= radius; z++) {
+                        positions.add(new Vec3i(x, y, z));
+                    }
+                }
+            }
+
+            BlockPos origin = blockHitResult.getBlockPos();
+
+            ItemStack handStack = playerEntity.getStackInHand(Hand.MAIN_HAND);
+            Item item = handStack.getItem();
+            if (item instanceof MagnaTool) {
+                origin = ((MagnaTool) item).getCenterPosition(world, playerEntity, blockHitResult, handStack);
+            }
+
+            // check if each position inside the box is valid
+            for(Vec3i pos : positions) {
+                boolean valid = false;
+
+                if(axis == Direction.Axis.Y) {
+                    if(pos.getY() == 0) {
+                        potentialBrokenBlocks.add(origin.add(pos));
+                        valid = true;
+                    }
+                }
+
+                else if (axis == Direction.Axis.X) {
+                    if(pos.getX() == 0) {
+                        potentialBrokenBlocks.add(origin.add(pos));
+                        valid = true;
+                    }
+                }
+
+                else if (axis == Direction.Axis.Z) {
+                    if(pos.getZ() == 0) {
+                        potentialBrokenBlocks.add(origin.add(pos));
+                        valid = true;
+                    }
+                }
+
+                // Operate on depth by extending the current block away from the player.
+                if(valid) {
+                    for (int i = 1; i <= depth; i++) {
+                        Vec3i vec = blockHitResult.getSide().getOpposite().getVector();
+                        potentialBrokenBlocks.add(origin.add(pos).add(vec.getX() * i, vec.getY() * i, vec.getZ() * i));
+                    }
+                }
+            }
+        }
+
+        return potentialBrokenBlocks;
+    }
+}

--- a/src/main/java/draylar/magna/api/MagnaTool.java
+++ b/src/main/java/draylar/magna/api/MagnaTool.java
@@ -139,7 +139,7 @@ public interface MagnaTool {
             int depth = getDepth(mainHandStack);
 
             // break blocks
-            BlockBreaker.breakInRadius(world, player, radius, depth, (view, breakPos) -> isBlockValidForBreaking(view, breakPos, mainHandStack), processor, true);
+            BlockBreaker.breakInRadius(world, player, radius, depth, getBlockFinder(), (view, breakPos) -> isBlockValidForBreaking(view, breakPos, mainHandStack), processor, true);
             return true;
         }
 
@@ -159,5 +159,13 @@ public interface MagnaTool {
      */
     default boolean renderOutline(World world, BlockHitResult ray, PlayerEntity player, ItemStack stack) {
         return true;
+    }
+
+    /**
+     * Provides the {@link BlockFinder} that determines the valid positions to break.
+     * @return the {@link BlockFinder} that this tool uses
+     */
+    default BlockFinder getBlockFinder() {
+        return BlockFinder.DEFAULT;
     }
 }

--- a/src/main/java/draylar/magna/mixin/WorldRendererMixin.java
+++ b/src/main/java/draylar/magna/mixin/WorldRendererMixin.java
@@ -1,7 +1,6 @@
 package draylar.magna.mixin;
 
 import draylar.magna.Magna;
-import draylar.magna.api.BlockBreaker;
 import draylar.magna.api.MagnaTool;
 import draylar.magna.api.event.ToolRadiusCallback;
 import draylar.magna.config.MagnaConfig;
@@ -68,27 +67,25 @@ public class WorldRendererMixin {
 
         // show extended outline if the player is holding a magna tool
         ItemStack heldStack = this.client.player.getInventory().getMainHandStack();
-        if (heldStack.getItem() instanceof MagnaTool && config.enableExtendedHitbox) {
-            MagnaTool tool = (MagnaTool) heldStack.getItem();
+        if (heldStack.getItem() instanceof MagnaTool tool && config.enableExtendedHitbox) {
 
             // do not show extended outline if player is sneaking and the config option is enabled
             if (!config.disableExtendedHitboxWhileSneaking || !client.player.isSneaking()) {
 
                 // only show extended outline for block raytraces
-                if (client.crosshairTarget instanceof BlockHitResult) {
+                if (client.crosshairTarget instanceof BlockHitResult crosshairTarget) {
                     // if the tool should not render outlines, abort mission now
                     if(!tool.renderOutline(world, (BlockHitResult) client.crosshairTarget, client.player, heldStack)) {
                         return;
                     }
 
-                    BlockHitResult crosshairTarget = (BlockHitResult) client.crosshairTarget;
                     BlockPos crosshairPos = crosshairTarget.getBlockPos();
                     BlockState crosshairState = client.world.getBlockState(crosshairPos);
 
                     // ensure we are not looking at air or an invalid block
                     if (!crosshairState.isAir() && client.world.getWorldBorder().contains(crosshairPos) && tool.isBlockValidForBreaking(world, crosshairPos, heldStack)) {
-                        int radius = ToolRadiusCallback.EVENT.invoker().getRadius(heldStack, ((MagnaTool) heldStack.getItem()).getRadius(heldStack));
-                        List<BlockPos> positions = BlockBreaker.findPositions(world, client.player, radius, tool.getDepth(heldStack));
+                        int radius = ToolRadiusCallback.EVENT.invoker().getRadius(heldStack, tool.getRadius(heldStack));
+                        List<BlockPos> positions = tool.getBlockFinder().findPositions(world, client.player, radius, tool.getDepth(heldStack));
                         List<VoxelShape> outlineShapes = new ArrayList<>();
                         outlineShapes.add(VoxelShapes.empty());
 
@@ -158,8 +155,7 @@ public class WorldRendererMixin {
         ItemStack heldStack = this.client.player.getInventory().getMainHandStack();
 
         // make sure we should display the outline based on the tool
-        if (heldStack.getItem() instanceof MagnaTool && config.enableAllBlockBreakingAnimation) {
-            MagnaTool tool = (MagnaTool) heldStack.getItem();
+        if (heldStack.getItem() instanceof MagnaTool tool && config.enableAllBlockBreakingAnimation) {
 
             // check if we should display the outline based on config and sneaking
             if (!config.disableExtendedHitboxWhileSneaking || !client.player.isSneaking()) {
@@ -174,10 +170,10 @@ public class WorldRendererMixin {
                     if (infos != null && !infos.isEmpty() && tool.isBlockValidForBreaking(world, crosshairPos, heldStack)) {
                         BlockBreakingInfo breakingInfo = infos.last();
                         int stage = breakingInfo.getStage();
-                        int radius = ToolRadiusCallback.EVENT.invoker().getRadius(heldStack, ((MagnaTool) heldStack.getItem()).getRadius(heldStack));
+                        int radius = ToolRadiusCallback.EVENT.invoker().getRadius(heldStack, tool.getRadius(heldStack));
 
                         // collect positions for displaying outlines at
-                        List<BlockPos> positions = BlockBreaker.findPositions(world, client.player, radius, tool.getDepth(heldStack));
+                        List<BlockPos> positions = tool.getBlockFinder().findPositions(world, client.player, radius, tool.getDepth(heldStack));
                         Long2ObjectMap<BlockBreakingInfo> map = new Long2ObjectLinkedOpenHashMap<>(positions.size());
 
                         // filter positions

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -8,7 +8,8 @@
     "Draylar"
   ],
   "contributors": [
-    "GabrielOlvH"
+    "GabrielOlvH",
+    "Platymemo"
   ],
   "contact": {
     "homepage": "https://github.com/Draylar/magna",


### PR DESCRIPTION
This PR extracts out position finding to a separate interface, `BlockFinder`. This allows users to custom define patterns with much more control.

An example tool is added to use this new feature.

No backward compatibility should be broken.